### PR TITLE
Add auto-discovery to the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ Via Composer
 $ composer require casdr/laravel-moneybird
 ```
 
-Add the ServiceProvider and the Facade to your `config/app.php`:
+Laravel uses Package Auto-Discovery, so doesn't require you to manually add the ServiceProvider.
+
+### Laravel without auto-discovery:
+
+If you don't use auto-discovery, add the ServiceProvider and the Facade to your `config/app.php`:
 
 ```php
 'providers' => [
@@ -48,7 +52,7 @@ return [
 
 ## Usage
 
-``` php 
+``` php
 $contact = Moneybird::contact();
 
 $contact->company_name = 'BlaLabs';

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,15 @@
         "psr-4": {
             "Casdr\\Moneybird\\": "src"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Casdr\\Moneybird\\MoneybirdServiceProvider"
+            ],
+            "aliases": {
+                "Moneybird": "Casdr\\Moneybird\\MoneybirdFacade"
+            }
+        }
     }
 }


### PR DESCRIPTION
Since Laravel version 5.5, it supports autodiscover, which removes the need to manually add the ServiceProvider and Facade to your config/app.php.

This is simply done by adding the "extra" part in composer.json, which makes it backwards-compatible.

If accepted, would be nice if the PR can be labeled with "hacktoberfest-accepted".


Have a great day!